### PR TITLE
Google analytics privacy options for GDPR compliance

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -43,6 +43,13 @@ canonifyurls    = true
   #casper or caspertwo
   singleViewStyle = "casper"
 
+[privacy]
+  [privacy.googleAnalytics]
+    anonymizeIP = true
+    disable = false
+    respectDoNotTrack = true
+    useSessionStorage = true
+
 [permalinks]
   post = "/post/:slug/"
 


### PR DESCRIPTION
Giving option to tweak privacy settings if using Google Analytics

https://gohugo.io/about/hugo-and-gdpr/#the-privacy-settings-explained